### PR TITLE
Added hscript_in_macro flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,7 @@ This function will add and keep all the std classes to be available at run-time 
 #### Compilation directives
  - `-D hscriptPos` to report error line related to hscript macro exprs generator.
  - `-D hscript_template_macro_pos` to report error line related to generated expressions.
+ - `-D hscript_in_macro` to use run time-style templating in macro context (e.g., when using in your own macros).
 
 #### Notes 
 *With the automatic build, the source file path is relative to the class file.*

--- a/ftk/format/template/Parser.hx
+++ b/ftk/format/template/Parser.hx
@@ -59,7 +59,7 @@ class Parser{
 		
 		var isInsideExpr	= false;
 		var doWriteText		= true;
-#if ( !macro || ( macro && hscript_template_macro_pos ) )
+#if ( !macro || ( macro && hscript_template_macro_pos ) || hscript_in_macro )
 		var switchTextFlow	= [];
 #end
 		while( true ){
@@ -75,7 +75,7 @@ class Parser{
 					continue;
 				case ECase(_)	:
 					flow.push( t );
-#if ( !macro || ( macro && hscript_template_macro_pos ) )
+#if ( !macro || ( macro && hscript_template_macro_pos ) || hscript_in_macro )
 					flow			= flow.concat( switchTextFlow );
 					switchTextFlow	= [];
 #end
@@ -88,7 +88,7 @@ class Parser{
 			if( doWriteText ){
 				flow.push( t );
 			}
-#if ( !macro || ( macro && hscript_template_macro_pos ) )
+#if ( !macro || ( macro && hscript_template_macro_pos ) || hscript_in_macro )
 			else{
 				switchTextFlow.push( t );
 			}
@@ -96,10 +96,10 @@ class Parser{
 		}
 
 		var isInComment	= false;
-#if ( !macro || ( macro && hscript_template_macro_pos ) )
+#if ( !macro || ( macro && hscript_template_macro_pos ) || hscript_in_macro )
 		comments	= "";
 #end
-#if macro
+#if (macro && !hscript_in_macro)
 		out	= '{var __comments__=[];var __s__="";';
 #else
 		out	= '{__comments__=[];__s__="";';
@@ -115,7 +115,7 @@ class Parser{
 					}
 				case EExpr( s ) : 
 					if( s.startsWith( COMMENT ) && s.endsWith( COMMENT ) ){
-#if ( !macro || ( macro && hscript_template_macro_pos ) )
+#if ( !macro || ( macro && hscript_template_macro_pos ) || hscript_in_macro )
 						out	+= '__comments__.push("' + ( SIGN + SIGN + s + SIGN + SIGN ).split( '"' ).join( '\\"' ) + '");';
 #end
 					}else if( s.startsWith( COMMENT ) ){
@@ -123,7 +123,7 @@ class Parser{
 						addComment( s );
 					}else if( s.endsWith( COMMENT ) ){
 						addComment( s );
-#if ( !macro || ( macro && hscript_template_macro_pos ) )
+#if ( !macro || ( macro && hscript_template_macro_pos ) || hscript_in_macro )
 						comments	= comments.split( '"' ).join( '\\"' );
 						out	+= '__comments__.push("' + comments + '");';
 						comments	= "";
@@ -133,7 +133,7 @@ class Parser{
 						if( isInComment ){
 							addComment( s );
 						}else{
-#if macro
+#if (macro && !hscript_in_macro)
 							out	+= '__s__+=$s;';
 #else
 							out	+= '__s__+=__toString__( $s );';
@@ -207,7 +207,7 @@ class Parser{
 	}
 
 	inline function addComment( s : String, isText = false ){
-#if ( !macro || ( macro && hscript_template_macro_pos ) )
+#if ( !macro || ( macro && hscript_template_macro_pos ) || hscript_in_macro )
 		if( isText ){
 			comments	+= s;
 		}else{

--- a/ftk/format/template/Template.hx
+++ b/ftk/format/template/Template.hx
@@ -1,6 +1,6 @@
 package ftk.format.template;
 
-#if macro
+#if (macro && !hscript_in_macro)
 import haxe.macro.Expr;
 import haxe.macro.Context;
 import haxe.macro.Compiler;
@@ -14,7 +14,7 @@ import hscript.Tools;
 #end
 
 using StringTools;
-#if macro
+#if (macro && !hscript_in_macro)
 using haxe.macro.ExprTools;
 #else
 using hscript.Tools;
@@ -25,7 +25,7 @@ using hscript.Tools;
  * @author filt3rek
  */
 
-#if !macro
+#if (!macro || hscript_in_macro)
 class TemplateError {
 	public var source	(default,null)	: Null<String>;
 	public var native	(default,null)	: Error;
@@ -49,7 +49,7 @@ class Template {
 
 	static var stdClasses	= [ "Std", "Math", "Date", "StringTools", "DateTools", "Lambda", "haxe.ds.StringMap", "haxe.ds.IntMap", "haxe.ds.ObjectMap" ];
 
-#if macro
+#if (macro && !hscript_in_macro)
 	static var templateMeta		= ":template";
 	static var processedTypes	= [];
 #else
@@ -239,7 +239,7 @@ class Template {
 	*/
 
 	public static function buildTemplates( pathFilter = "", recursive = false, ?templateMeta : String, ?pos : haxe.PosInfos ){
-#if macro
+#if (macro && !hscript_in_macro)
 #if hscript_template_build_trace
 		trace( pos.fileName );
 #end
@@ -258,7 +258,7 @@ class Template {
 	*/
 
 	public static function addStd(){
-#if macro
+#if (macro && !hscript_in_macro)
 		for( cname in stdClasses ){
 			haxe.macro.Compiler.addMetadata( "@:keep", cname );
 		}
@@ -277,7 +277,7 @@ class Template {
 	*	Add `-D hscript_template_macro_pos` to report error line related to generated expressions
 	*/
 
-#if macro
+#if (macro && !hscript_in_macro)
 	public static function build() : Array<Field> {
 		var tname	= switch Context.getLocalType(){
 			case 	TInst(_.toString()=>s,_), TAbstract(_.toString()=>s,_)	: s;
@@ -344,6 +344,7 @@ class Template {
 	*	Add `-D hscript_template_macro_pos` to report error line related to generated expressions
 	*/
 
+#if (macro && !hscript_in_macro)
 	macro public static function buildFromFile( path : String, ?isFullPath : Bool ) {
 #if display
 		return;
@@ -446,7 +447,6 @@ class Template {
 
 	//
 
-#if macro
 #if hscript_template_macro_pos
 	static function checkExpr( expr : Expr, exprsBuf : Array<Expr>, line : Int, content : String, path : String ) : Int {
 		var skip	= true;


### PR DESCRIPTION
This lib looked useful to me because every other templating system required the macro system, which prevented me from using it because I need access to templating inside the context of macros I'm making. However, since `macro` is defined while I'm in macro, the run-time code is inaccessible so I figured the least intrusive way to make this work for me was to add an additional flag when you want the hscript-based behavior to be accessible in macros with `-D hscript_in_macro`